### PR TITLE
fix(systemd): use oneshot units instead of simple ones for better handling

### DIFF
--- a/systemd/alert-missing.service
+++ b/systemd/alert-missing.service
@@ -3,7 +3,7 @@ Description=Backend service - alert for incorrect signs
 After=multi-user.target
 
 [Service]
-Type=simple
+Type=oneshot
 Restart=no
 ExecStart=/opt/vde/venv/bin/python3 "/opt/vde/alerts.py" --m sign
 

--- a/systemd/alert-signs.service
+++ b/systemd/alert-signs.service
@@ -3,7 +3,7 @@ Description=Backend service - alert for missing data
 After=multi-user.target
 
 [Service]
-Type=simple
+Type=oneshot
 Restart=no
 ExecStart=/opt/vde/venv/bin/python3 "/opt/vde/alerts.py" --m missing
 

--- a/systemd/sync-raw-flukso-data.service
+++ b/systemd/sync-raw-flukso-data.service
@@ -3,7 +3,7 @@ Description=Backend service - sync raw data
 After=multi-user.target
 
 [Service]
-Type=simple
+Type=oneshot
 Restart=no
 ExecStart=/opt/vde/venv/bin/python3 "/opt/vde/syncRawFluksoData.py"
 TimeoutSec=5hours

--- a/systemd/sync-sftp.service
+++ b/systemd/sync-sftp.service
@@ -3,7 +3,7 @@ Description=Backend service - sync to sftp server
 After=multi-user.target
 
 [Service]
-Type=simple
+Type=oneshot
 Restart=no
 ExecStart=/opt/vde/venv/bin/python3 "/opt/vde/syncSftp.py"
 

--- a/systemd/vde-server-frontend.service
+++ b/systemd/vde-server-frontend.service
@@ -3,6 +3,7 @@ Description=frontend systemd service - production
 After=multi-user.target
 
 [Service]
+Type=simple
 ExecStart=/usr/bin/node "/opt/vde/webapp/server.js"
 Restart=always
 StandardOutput=syslog

--- a/systemd/vde-sync-rtu.service
+++ b/systemd/vde-sync-rtu.service
@@ -3,10 +3,10 @@ Description=Backend service - sync RTU data
 After=multi-user.target network.target
 
 [Service]
-Type=simple
+Type=oneshot
 Restart=no
 ExecStart=/opt/vde/venv/bin/python3 "/opt/vde/sync_rtu.py"
-TimeoutSec=5hours
+TimeoutSec=4minutes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Simple units are made to manage continuous applications while oneshot are designed to manage scripts. Oneshot units are never running: they start and they die. This makes the TimeoutSec option effective because it concerns the starting and stopping phases.